### PR TITLE
FCRM-4004 added in a schema that allows the optional ltfConnectionString

### DIFF
--- a/config/schema.js
+++ b/config/schema.js
@@ -7,7 +7,8 @@ const serverSchema = Joi.object().required().keys({
 })
 
 const databaseSchema = Joi.object().required().keys({
-  connectionString: Joi.string().required()
+  connectionString: Joi.string().required(),
+  ltfConnectionString: Joi.string()
 })
 
 module.exports = Joi.object({

--- a/server/routes/get-surface-water-by-polygon.js
+++ b/server/routes/get-surface-water-by-polygon.js
@@ -1,0 +1,31 @@
+const Joi = require('joi')
+const Boom = require('@hapi/boom')
+const services = require('../services')
+
+module.exports = {
+  method: 'GET',
+  path: '/surface-water-by-polygon',
+  options: {
+    description: 'Gets the surface water data for a polygon and radius',
+    handler: async (request, h) => {
+      try {
+        console.log(request.query.polygon, request.query.radius)
+        const result = await services.getSurfaceWaterByPolygon(request.query.polygon, request.query.radius || 0)
+
+        if (!result || !Array.isArray(result.rows) || result.rows.length !== 1) {
+          return Boom.badRequest('Invalid result', new Error('Expected an Array'))
+        }
+
+        return result.rows[0].calculate_surface_water_risk_from_polygon
+      } catch (err) {
+        return Boom.badImplementation('Database call failed', err)
+      }
+    },
+    validate: {
+      query: Joi.object().keys({
+        polygon: Joi.string().required(),
+        radius: Joi.number().integer().positive()
+      })
+    }
+  }
+}

--- a/server/routes/get-surface-water.js
+++ b/server/routes/get-surface-water.js
@@ -1,0 +1,31 @@
+const Joi = require('joi')
+const Boom = require('@hapi/boom')
+const services = require('../services')
+
+module.exports = {
+  method: 'GET',
+  path: '/surface-water/{easting}/{northing}/{radius}',
+  options: {
+    description: 'Gets the surface water data for a point and radius',
+    handler: async (request, h) => {
+      try {
+        const result = await services.getSurfaceWater(request.params.easting, request.params.northing, request.params.radius)
+
+        if (!result || !Array.isArray(result.rows) || result.rows.length !== 1) {
+          return Boom.badRequest('Invalid result', new Error('Expected an Array'))
+        }
+
+        return result.rows[0].calculate_surface_water_risk
+      } catch (err) {
+        return Boom.badImplementation('Database call failed', err)
+      }
+    },
+    validate: {
+      params: Joi.object().keys({
+        easting: Joi.number().max(700000).positive().required(),
+        northing: Joi.number().max(1300000).positive().required(),
+        radius: Joi.number().integer().positive().required()
+      })
+    }
+  }
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -6,4 +6,7 @@ module.exports = [].concat(
   require('./test-db'),
   require('./zones'),
   require('./zones-data'),
-  require('./zones-by-polygon'))
+  require('./zones-by-polygon'),
+  require('./get-surface-water'),
+  require('./get-surface-water-by-polygon')
+)

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,9 +1,12 @@
 const queries = require('./queries.json')
 const conn = require('../../config').database.connectionString
+const ltfConnectionString = require('../../config').database.ltfConnectionString
 const { Pool } = require('pg')
 const pool = new Pool({
   connectionString: conn
 })
+
+const ltfPool = ltfConnectionString ? new Pool({ connectionString: ltfConnectionString}) : undefined
 
 module.exports = {
   getFloodZones: (x, y, radius) => {
@@ -16,5 +19,17 @@ module.exports = {
     return pool.query(queries.isEngland, [x, y])
   },
   getPsoContacts: (x, y) => pool.query(queries.getPsoContacts, [x, y]),
-  getPsoContactsByPolygon: polygon => pool.query(queries.getPsoContactsByPolygon, [polygon])
+  getPsoContactsByPolygon: polygon => pool.query(queries.getPsoContactsByPolygon, [polygon]),
+  getSurfaceWater: (x, y, radius = 10) => {
+    if (ltfPool) {
+      return ltfPool.query(queries.getSurfaceWater, [x, y, radius])
+    }
+    return {rows: [{calculate_surface_water_risk: {}}]}
+  },
+  getSurfaceWaterByPolygon: (polygon, radius = 0) => {
+    if (ltfPool) {
+      return ltfPool.query(queries.getSurfaceWaterByPolygon, [polygon, radius])
+    }
+    return {rows: [{calculate_surface_water_risk_from_polygon: {}}]}
+  }
 }

--- a/server/services/queries.json
+++ b/server/services/queries.json
@@ -3,5 +3,7 @@
     "getFloodZonesByPolygon": "select fmp.get_fmp_zones_by_polygon($1);",
     "isEngland": "select fmp.is_england($1, $2);",
     "getPsoContacts": "select fmp.get_pso_contacts($1, $2);",
-    "getPsoContactsByPolygon": "select fmp.get_pso_contacts_by_polygon($1);"
+    "getPsoContactsByPolygon": "select fmp.get_pso_contacts_by_polygon($1);",
+    "getSurfaceWater": "select u_ltfri.calculate_surface_water_risk($1, $2, $3);",
+    "getSurfaceWaterByPolygon": "select u_ltfri.calculate_surface_water_risk_from_polygon($1, $2);"
 }


### PR DESCRIPTION
@pmshaw15 - Once Dave has merged the config change for the LTF copy of the data, the config on DEV will include the new entry.
This PR ensures that fmp-service will still work when 2.6 is deployed (it would crash when validating without this change).
It does mean that we are stuck on v2.6.0-pre.2 (or higher) for fmp-service, unless we add further complexity to the deploy scripts), but I think we can live with that as I have never had to roll back fmp-service on DEV.
ENVs beyond dev are not affected, but for DEV this is required in order to switch back to the same build as the release.

I will ask Ben to test this deployment on TST (which wont have the config), so we can be confident that other ENVs are not affected by this.